### PR TITLE
fix: resolve workspace name before PATCH masking_rule

### DIFF
--- a/.github/workflows/1-bb-masking-semantic-type-global.yml
+++ b/.github/workflows/1-bb-masking-semantic-type-global.yml
@@ -106,10 +106,17 @@ jobs:
         id: apply-global-masking-rule
         if: ${{ steps.changed-files.outputs.any_changed == 'true' && contains(steps.changed-files.outputs.all_changed_files, 'global-masking-rule.json') }}
         run: |
-          CHANGED_FILE="masking/global-masking-rule.json"     
+          CHANGED_FILE="masking/global-masking-rule.json"
           echo "Processing: $CHANGED_FILE"
-          
-          response=$(curl -s -w "\n%{http_code}" --request PATCH "${{ steps.bytebase-login.outputs.api_url }}/workspaces/-/policies/masking_rule?allowMissing=true&updateMask=payload" \
+
+          # Resolve the current workspace resource name. Policy URLs need the
+          # real workspace ID — "workspaces/-" only works for GetWorkspace.
+          WORKSPACE_NAME=$(curl -s \
+            --header "Authorization: Bearer ${{ steps.bytebase-login.outputs.token }}" \
+            "${{ steps.bytebase-login.outputs.api_url }}/workspaces/-" | jq -r '.name')
+          echo "Workspace: $WORKSPACE_NAME"
+
+          response=$(curl -s -w "\n%{http_code}" --request PATCH "${{ steps.bytebase-login.outputs.api_url }}/${WORKSPACE_NAME}/policies/masking_rule?allowMissing=true&updateMask=payload" \
             --header "Authorization: Bearer ${{ steps.bytebase-login.outputs.token }}" \
             --header "Content-Type: application/json" \
             --data @"$CHANGED_FILE")

--- a/.github/workflows/3-bb-masking-classification.yml
+++ b/.github/workflows/3-bb-masking-classification.yml
@@ -88,10 +88,17 @@ jobs:
         id: apply-global-masking-rule
         if: ${{ steps.changed-files.outputs.any_changed == 'true' && contains(steps.changed-files.outputs.all_changed_files, 'global-masking-rule-classification.json') }}
         run: |
-          CHANGED_FILE="masking/global-masking-rule-classification.json"     
+          CHANGED_FILE="masking/global-masking-rule-classification.json"
           echo "Processing: $CHANGED_FILE"
-          
-          response=$(curl -s -w "\n%{http_code}" --request PATCH "${{ steps.bytebase-login.outputs.api_url }}/workspaces/-/policies/masking_rule?allowMissing=true&updateMask=payload" \
+
+          # Resolve the current workspace resource name. Policy URLs need the
+          # real workspace ID — "workspaces/-" only works for GetWorkspace.
+          WORKSPACE_NAME=$(curl -s \
+            --header "Authorization: Bearer ${{ steps.bytebase-login.outputs.token }}" \
+            "${{ steps.bytebase-login.outputs.api_url }}/workspaces/-" | jq -r '.name')
+          echo "Workspace: $WORKSPACE_NAME"
+
+          response=$(curl -s -w "\n%{http_code}" --request PATCH "${{ steps.bytebase-login.outputs.api_url }}/${WORKSPACE_NAME}/policies/masking_rule?allowMissing=true&updateMask=payload" \
             --header "Authorization: Bearer ${{ steps.bytebase-login.outputs.token }}" \
             --header "Content-Type: application/json" \
             --data @"$CHANGED_FILE")


### PR DESCRIPTION
## Summary
- `workspaces/-` does **not** resolve to the current workspace for policy endpoints — only the `GetWorkspace` RPC has dash-expansion logic ([workspace_service.go:57](https://github.com/bytebase/bytebase/blob/main/backend/api/v1/workspace_service.go#L57))
- For policies, the resource string is passed through literally as an exact-match SQL filter ([common/resource_name.go:658](https://github.com/bytebase/bytebase/blob/main/backend/common/resource_name.go#L658), [store/policy.go:489](https://github.com/bytebase/bytebase/blob/main/backend/store/policy.go#L489))
- Existing workspace policies are stored with `resource = 'workspaces/{real_id}'` (migration [3.16/0001](https://github.com/bytebase/bytebase/blob/main/backend/migrator/migration/3.16/0001%23%23fix_workspace_policy_resource.sql) backfills this)
- Without this fix, a PATCH with `allowMissing=true` silently **creates a duplicate orphan** policy (`resource = 'workspaces/-'`) instead of updating the real one — the UI never sees it

Fetch the real workspace name via `GET /v1/workspaces/-` first, then use it in the masking_rule PATCH URL.

Follow-up to #96. Companion docs PR: bytebase/bytebase.com#1080

## Test plan
- [ ] Run workflow 1 against a Bytebase instance with an existing global masking rule (created via UI) — confirm the PATCH updates the existing policy instead of creating a duplicate
- [ ] Run workflow 3 (classification) — same verification
- [ ] Verify in the Bytebase UI that only one global masking rule exists after the workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)